### PR TITLE
Allow ElasticSearch to Accurately Report Schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ mysql interface, so if you are familiar with that, you already pretty much know 
 ## Installing the Library
 This library can be installed using [Composer](https://getcomposer.org) by using the following command:
 ```
-composer require "datadistillr/drill-sdk-php:^0.7.16"
+composer require "datadistillr/drill-sdk-php:^0.7.17"
 ```
 
-The current pre-release version is: `0.7.16`
+The current pre-release version is: `0.7.17`
 
 ## Using the Connector
 The first step is to make a Drill connection handle.  The module uses Drill's RESTful interface, so it will not

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ mysql interface, so if you are familiar with that, you already pretty much know 
 ## Installing the Library
 This library can be installed using [Composer](https://getcomposer.org) by using the following command:
 ```
-composer require "datadistillr/drill-sdk-php:^0.7.4"
+composer require "datadistillr/drill-sdk-php:^0.7.16"
 ```
 
-The current pre-release version is: `0.7.4`
+The current pre-release version is: `0.7.16`
 
 ## Using the Connector
 The first step is to make a Drill connection handle.  The module uses Drill's RESTful interface, so it will not

--- a/src/DrillConnection.php
+++ b/src/DrillConnection.php
@@ -1054,9 +1054,13 @@ class DrillConnection
 
         // Since MongoDB uses the ** notation, bypass that and query the data directly
         // TODO: Add API functionality here as well
-        if ($pluginType === 'file' || $pluginType === 'mongo' || $pluginType === 'splunk') {
+        if ($pluginType === 'file' || $pluginType === 'mongo' || $pluginType === 'splunk' || $pluginType === 'elastic') {
 
-            $views = $this->getViewNames($plugin, $schema);
+            $views = [];
+            // Views only exist in file systems
+            if ($pluginType === 'file') {
+              $views = $this->getViewNames($plugin, $schema);
+            }
 
             $pluginSchema = $plugin;
             if (isset($schema)) {
@@ -1112,7 +1116,7 @@ class DrillConnection
      */
     public function getFileColumns(string $fullformattedPath): array
     {
-
+        // TODO Populate the rest of the column data.
         $this->logMessage(LogType::Query, 'Starting getFileColumns');
 
         $columns = [];

--- a/test/DrillTest.php
+++ b/test/DrillTest.php
@@ -97,6 +97,15 @@ final class DrillTest extends TestCase
 		print_r($result);
 	}
 
+  public function testElasticSearchTree() {
+    $this->setup();
+    $dh = new DrillConnection(self::$host, self::$port, self::$username, self::$password, self::$ssl, self::$row_limit);
+
+    $result = $dh->getNestedTree('elastic', 'search-ddrtest');
+    $this->assertCount(15, $result);
+    print_r($result);
+  }
+
 	public function testPlugins() {
     $this->setup();
     $dh = new DrillConnection(self::$host, self::$port, self::$username, self::$password, self::$ssl, self::$row_limit);


### PR DESCRIPTION
# Allow ElasticSearch to Accurately Report Schemas

## Description
ElasticSearch (ES) plugins were reporting columns as `**`.  This bugfix corrects that and now ES columns will be correctly reported. 

One minor efficiency improvement.  The plugin was checking for views for mongo, elastic, and splunk.  Drill only supports views in file systems, so this code was removed.

## User Facing Changes
N/A

## Documentation
N/A

## External Dependencies
N/A

## Testing
Manually tested